### PR TITLE
fix Excel writer initialization causing IndexError

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,6 +6,7 @@ import io
 import math
 import datetime as dt
 from typing import Dict, Tuple
+import openpyxl  # noqa: F401  # Ensure Excel engine is available
 
 st.set_page_config(
     page_title="経営計画策定（単年）｜Streamlit",
@@ -593,9 +594,6 @@ with tab_export:
         return df
 
     df_sens = recompute_sensitivity_table()
-    import io
-    with pd.ExcelWriter(io.BytesIO(), engine="openpyxl") as tmp:
-        pass  # ensure openpyxl is imported
 
     output = io.BytesIO()
     with pd.ExcelWriter(output, engine="openpyxl") as writer:


### PR DESCRIPTION
## Summary
- ensure openpyxl is imported for Excel exports
- remove empty ExcelWriter placeholder that caused `At least one sheet must be visible` errors

## Testing
- `python -m py_compile app.py`
- `python - <<'PY'
import io, pandas as pd
from app import compute, PlanConfig
plan=PlanConfig(base_sales=1e6, fte=10, unit="百万円")
plan.set_rate("COGS_MAT", 0.1)
plan.set_rate("OPEX_H",0.2)
compute(plan)
output=io.BytesIO()
with pd.ExcelWriter(output, engine='openpyxl') as writer:
    pd.DataFrame([compute(plan)]).to_excel(writer)
print('bytes', len(output.getvalue()))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b43e33873c8323860774a2bb0c2343