### PR TITLE
Handle empty Excel exports

### DIFF
--- a/app.py
+++ b/app.py
@@ -597,9 +597,18 @@ with tab_export:
 
     output = io.BytesIO()
     with pd.ExcelWriter(output, engine="openpyxl") as writer:
-        df_num.to_excel(writer, sheet_name="金額", index=True)
-        df_kpi.to_excel(writer, sheet_name="KPI", index=True)
-        df_sens.to_excel(writer, sheet_name="感応度", index=False)
+        sheets_written = 0
+        if isinstance(df_num, pd.DataFrame) and not df_num.empty:
+            df_num.to_excel(writer, sheet_name="金額", index=True)
+            sheets_written += 1
+        if isinstance(df_kpi, pd.DataFrame) and not df_kpi.empty:
+            df_kpi.to_excel(writer, sheet_name="KPI", index=True)
+            sheets_written += 1
+        if isinstance(df_sens, pd.DataFrame) and not df_sens.empty:
+            df_sens.to_excel(writer, sheet_name="感応度", index=False)
+            sheets_written += 1
+        if sheets_written == 0:
+            pd.DataFrame().to_excel(writer, sheet_name="Sheet1")
     data = output.getvalue()
 
     st.download_button(


### PR DESCRIPTION
## Summary
- avoid openpyxl IndexError when no DataFrame sheets are written
- add placeholder worksheet when exporting Excel if all DataFrames are empty

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b442add110832387b12de1cebad310